### PR TITLE
Adding missing label to IoT-Agent container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ jspm_packages/
 .eslintcache
 *.tgz
 .next
+.idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,9 @@ version: "3.8"
 services:
   # Orion is the context broker
   orion:
+    image: quay.io/fiware/orion:${ORION_VERSION}
     labels:
       org.fiware: 'tutorial'
-    image: quay.io/fiware/orion:${ORION_VERSION}
     hostname: orion
     container_name: fiware-orion
     depends_on:
@@ -41,6 +41,8 @@ services:
   # IoT-Agent is configured for the JSON Protocol
   iot-agent:
     image: quay.io/fiware/iotagent-json:${JSON_VERSION}
+    labels:
+      org.fiware: 'tutorial'
     hostname: iot-agent
     container_name: fiware-iot-agent
     depends_on:
@@ -75,9 +77,9 @@ services:
 
   # Tutorial acts as a series of dummy IoT Sensors over HTTP
   tutorial:
+    image: quay.io/fiware/tutorials.context-provider
     labels:
       org.fiware: 'tutorial'
-    image: quay.io/fiware/tutorials.context-provider
     hostname: iot-sensors
     container_name: fiware-tutorial
     depends_on:
@@ -112,9 +114,9 @@ services:
 
   # Database
   mongo-db:
+    image: mongo:${MONGO_DB_VERSION}
     labels:
       org.fiware: 'tutorial'
-    image: mongo:${MONGO_DB_VERSION}
     hostname: mongo-db
     container_name: db-mongo
     expose:


### PR DESCRIPTION
Correct some inconsistencies in the docker compose file (missing label in the iot-agent container) that produce an error in the execution of the service stop