### PR TITLE
fix issue with static attributes in the current tutorial requests

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -605,7 +605,7 @@ curl -iX POST \
    {
      "apikey":      "4jggokgpepnvsb2uv4s40d59ov",
      "cbroker":     "http://orion:1026",
-     "entity_type": "Thing",
+     "entity_type": "Motion",
      "resource":    "/iot/json"
    }
  ]

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ curl -iX POST \
    {
      "apikey":      "4jggokgpepnvsb2uv4s40d59ov",
      "cbroker":     "http://orion:1026",
-     "entity_type": "Thing",
+     "entity_type": "Motion",
      "resource":    "/iot/json"
    }
  ]


### PR DESCRIPTION
The current tutorial requests have an issue that if you execute them one by one, the static attributes don't get included into the device entity in the context broker, which makes them not query-able.

This is mentioned in an issue on the iotagent-json repo: [https://github.com/telefonicaid/iotagent-json/issues/835](https://github.com/telefonicaid/iotagent-json/issues/835).

The solution is to either set the service group `entity_type` to match the `entity_type` of the device when provisioned (*which is what I've done for now*) or to *also* include the service's `apikey` for the device when provisioning the device (*which I've not included by now*).